### PR TITLE
Feature/In-app chat errors handling improvement

### DIFF
--- a/infobip-mobile-messaging-android-chat-sdk/src/main/java/org/infobip/mobile/messaging/chat/view/InAppChatView.kt
+++ b/infobip-mobile-messaging-android-chat-sdk/src/main/java/org/infobip/mobile/messaging/chat/view/InAppChatView.kt
@@ -129,7 +129,7 @@ class InAppChatView @JvmOverloads constructor(
 
             val snackbarView = snackbar.view
             val textView = snackbarView.findViewById<TextView>(R.id.snackbar_text)
-            textView.maxLines = 4 // Here we set the max lines for the TextView within the Snackbar
+            textView.maxLines = 4
 
             snackbar.show()
         }
@@ -139,8 +139,9 @@ class InAppChatView @JvmOverloads constructor(
         }
     }
 
-
-    // Utility function to parse the JSON error message
+    /**
+     * Utility function to parse the JSON error message
+     */
     fun parseJsonError(errorJson: String): Pair<String, String?> {
         return try {
             val jsonObject = JSONObject(errorJson)


### PR DESCRIPTION
# #39 Implement Errors handling by implementing json parser 

## Testing:

### Error triggering:

I have triggered error in `infobip-mobile-messaging-android-chat-sdk/src/main/assets/inappchat-widget.html` by triggering on error function:

**Trigger long error with long message:**
![Screenshot 2023-11-11 at 12 01 45](https://github.com/infobip/mobile-messaging-sdk-android/assets/62174446/a2ef7556-4c76-478e-80ee-1832a9101c99)

**Trigger error with message undefined**
![Screenshot 2023-11-11 at 12 01 36](https://github.com/infobip/mobile-messaging-sdk-android/assets/62174446/eed60542-0b77-442f-92a4-6e0f8beb16fc)

I have stick to the provided structure of error:

``` javascript
interface ErrorType {
    code: number;
    message: string | undefined;
}
```
---

### Error displaying:

**Displaying error with long message:**
![longerror](https://github.com/infobip/mobile-messaging-sdk-android/assets/62174446/70860943-4cf1-420d-8eb1-4775cf593992)

**Displaying error with message undefined**
![messageundefined](https://github.com/infobip/mobile-messaging-sdk-android/assets/62174446/e84099fa-d6de-47fe-ba05-908d8a7c9e1e)


