### PR TITLE
Fix: Correct Simplified Chinese strings appearing in Traditional Chinese locale

### DIFF
--- a/infobip-mobile-messaging-android-resources/src/main/res/values-b+zh+Hant/strings.xml
+++ b/infobip-mobile-messaging-android-resources/src/main/res/values-b+zh+Hant/strings.xml
@@ -12,6 +12,6 @@
     <string name="mm_button_open">打開</string>
     <string name="mm_button_cancel">取消</string>
     <string name="mm_button_settings">設定值</string>
-    <string name="mm_post_notifications_settings_title">更新通知设置</string>
-    <string name="mm_post_notifications_settings_message">允许应用程序一直发送推送通知，即使在应用程序关闭或未使用时也能触发通知</string>
+    <string name="mm_post_notifications_settings_title">更新通知設定</string>
+    <string name="mm_post_notifications_settings_message">允許應用程式進行推播通知，即使在應用程式關閉或未使用時，您仍能收到通知。</string>
 </resources>

--- a/infobip-mobile-messaging-android-resources/src/main/res/values-zh-rTW/strings.xml
+++ b/infobip-mobile-messaging-android-resources/src/main/res/values-zh-rTW/strings.xml
@@ -12,6 +12,6 @@
     <string name="mm_button_open">打開</string>
     <string name="mm_button_cancel">取消</string>
     <string name="mm_button_settings">設定值</string>
-    <string name="mm_post_notifications_settings_title">更新通知设置</string>
-    <string name="mm_post_notifications_settings_message">允许应用程序一直发送推送通知，即使在应用程序关闭或未使用时也能触发通知</string>
+    <string name="mm_post_notifications_settings_title">更新通知設定</string>
+    <string name="mm_post_notifications_settings_message">允許應用程式進行推播通知，即使在應用程式關閉或未使用時，您仍能收到通知。</string>
 </resources>


### PR DESCRIPTION

## Summary
Fixed incorrect Simplified Chinese (简体) strings that were mistakenly used in the Traditional Chinese (繁體) locale resource files.

## Changes
Updated two notification-related strings in both `values-b+zh+Hant/strings.xml` and `values-zh-rTW/strings.xml`:

| Key | Before (Simplified) | After (Traditional) |
|---|---|---|
| `mm_post_notifications_settings_title` | 更新通知设置 | 更新通知設定 |
| `mm_post_notifications_settings_message` | 允许应用程序一直发送 推送通知，即使在应用程序关闭或未使用时也能触发通知 | 允許應用程式進行推播 通知，即使在應用程式關閉或未使用時，您仍能收到通知。 |

## Context
The Traditional Chinese locale (`zh-Hant` / `zh-rTW`) resource files contained Simplified Chinese characters (e.g. 设置, 允许, 应用程序) instead of the correct Traditional Chinese equivalents (設定, 允許, 應用程式). This caused users on Traditional Chinese devices to see Simplified Chinese text in notification permission dialogs.